### PR TITLE
[BUGFIX] Removed roave/security-advisories as it break tests in TYPO3…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
 		"typo3/cms-core": "^10.4.19 || ^11.5"
 	},
 	"require-dev": {
-		"roave/security-advisories": "dev-latest",
 		"friendsofphp/php-cs-fixer": "^3.0",
 		"nimut/testing-framework": "^6.0",
 		"phpunit/phpunit": "^9.5",


### PR DESCRIPTION
… version 10